### PR TITLE
Added a MakeCredential helper that takes AK name directly

### DIFF
--- a/make_cred.go
+++ b/make_cred.go
@@ -62,7 +62,7 @@ func MakeCredential(cred, ekPublic, akPublic []byte) ([]byte, []byte, error) {
 
 // MakeCredentialUsingName uses the AK name directly and does not try to
 // compute it. The credential blob and the encrypted seed are returned.
-func MakeCredential(cred, ekPublic, akName []byte) ([]byte, []byte, error) {
+func MakeCredentialUsingName(cred, ekPublic, akName []byte) ([]byte, []byte, error) {
 	// Decode endorsement and attestation key public areas.
 	ekPub, err := tpm2.DecodePublic(ekPublic)
 	if err != nil {
@@ -342,7 +342,7 @@ func generateCredentialBlobUsingName(ekPub tpm2.Public, akName []byte, cred, see
 	// Compute the HMAC
 	mac := hmac.New(newHash, macKey)
 	mac.Write(encIdentity)
-	mac.Write(name)
+	mac.Write(akName)
 	macSum := mac.Sum(nil)
 
 	// Create and return the credential blob.


### PR DESCRIPTION
Allows AK name to be provided directly, instead of computing it.

In our case, the [EnactTrust](https://www.enacttrust.com) remote attestation server does not transfer the complete TPM2B_PUBLIC. Instead, we pass on just the TPM2B_NAME. Costs us fewer bytes and computation time. Considering we would perform MakeCredential on every attestation, this minor save accumulates over time.

Please test before merging :)

Signed-off-by: Dimitar Tomov <dimi@tpm.dev>